### PR TITLE
Add optional support for PROXY protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppp"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d901d7dd743c478e14af9518bdbc33e53e50be56429233f812537f29dbf0d1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +679,7 @@ dependencies = [
  "env_logger",
  "futures-util",
  "log",
+ "ppp",
  "tokio",
  "tokio-tungstenite",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { version = "1.14.0", features = ["rt", "net", "rt-multi-thread", "io-ut
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 log = "0.4"
 env_logger = "0.9.0"
+ppp = "2.2.0"
 
 [profile.release]
 opt-level = 3

--- a/src/common.rs
+++ b/src/common.rs
@@ -11,19 +11,19 @@ use log::{debug, error, info, trace, warn};
 
 pub enum TcpOrDestination {
     Tcp(TcpStream),
-    Dest(String),
+    Dest(String, bool),
 }
 
 pub async fn communicate(tcp_in: TcpOrDestination, ws_in: TcpOrDestination) -> Result<(), Error> {
     let mut ws;
-    let tcp;
+    let mut tcp;
 
     match tcp_in {
         TcpOrDestination::Tcp(src_stream) => {
             // Convert the source stream into a websocket connection.
             ws = accept_async(tokio_tungstenite::MaybeTlsStream::Plain(src_stream)).await?;
         }
-        TcpOrDestination::Dest(dest_location) => {
+        TcpOrDestination::Dest(dest_location, _) => {
             let (wsz, _) = match connect_async(dest_location).await {
                 Ok(v) => v,
                 Err(e) => {
@@ -42,7 +42,7 @@ pub async fn communicate(tcp_in: TcpOrDestination, ws_in: TcpOrDestination) -> R
         TcpOrDestination::Tcp(v) => {
             tcp = v;
         }
-        TcpOrDestination::Dest(dest_location) => {
+        TcpOrDestination::Dest(dest_location, proxy) => {
             // Try to setup the tcp stream we'll be communicating to, if this fails, we close the websocket.
             tcp = match TcpStream::connect(dest_location).await {
                 Ok(e) => e,
@@ -62,6 +62,23 @@ pub async fn communicate(tcp_in: TcpOrDestination, ws_in: TcpOrDestination) -> R
                     read.for_each(|_message| async {}).await;
                     return Err(Box::new(v));
                 }
+            };
+
+            if proxy {
+                let (src_addr, dst_addr) = match ws.get_ref() {
+                    tokio_tungstenite::MaybeTlsStream::Plain(s) => {
+                        (s.peer_addr()?, s.local_addr()?)
+                    }
+                    _ => return Err(Error::from("unknown tls implementation")),
+                };
+                let proxy_header = ppp::v2::Builder::with_addresses(
+                    ppp::v2::Version::Two | ppp::v2::Command::Proxy,
+                    ppp::v2::Protocol::Stream,
+                    (src_addr, dst_addr),
+                )
+                .build()?;
+
+                tcp.write(proxy_header.as_slice()).await?;
             }
         }
     }
@@ -235,7 +252,7 @@ pub async fn communicate(tcp_in: TcpOrDestination, ws_in: TcpOrDestination) -> R
 }
 
 pub enum Direction {
-    WsToTcp,
+    WsToTcp(bool),
     TcpToWs,
 }
 
@@ -247,7 +264,7 @@ pub async fn serve(bind_location: &str, dest_location: &str, dir: Direction) -> 
 
     loop {
         let in1 = match dir {
-            Direction::WsToTcp => {
+            Direction::WsToTcp(_) => {
                 let (socket, _) = listener
                     .accept()
                     .await
@@ -265,11 +282,11 @@ pub async fn serve(bind_location: &str, dest_location: &str, dir: Direction) -> 
                 } else {
                     ""
                 };
-                TcpOrDestination::Dest(proto_addition.to_owned() + dest_location)
+                TcpOrDestination::Dest(proto_addition.to_owned() + dest_location, false)
             }
         };
         let in2 = match dir {
-            Direction::WsToTcp => TcpOrDestination::Dest(dest_location.to_owned()),
+            Direction::WsToTcp(proxy) => TcpOrDestination::Dest(dest_location.to_owned(), proxy),
             Direction::TcpToWs => {
                 let (socket, _) = listener
                     .accept()

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Error> {
             Arg::with_name("v")
                 .short("v")
                 .multiple(true)
-                .help("Verbosity, add more for more verbose output."),
+                .help("Increases the verbosity"),
         )
         .arg(
             Arg::with_name("proxy")

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,23 +93,15 @@ fn main() -> Result<(), Error> {
             "Couldn't find mode value.",
             clap::ErrorKind::EmptyValue,
         ))? {
-        "ws_to_tcp" => common::Direction::WsToTcp(proxy),
-        "tcp_to_ws" => {
-            if proxy {
-                return Err(Box::new(clap::Error::with_description(
-                    "proxy is not allowed in tcp_to_ws mode",
-                    clap::ErrorKind::ArgumentConflict,
-                )));
-            }
-            common::Direction::TcpToWs
-        }
+        "ws_to_tcp" => common::Direction::WsToTcp,
+        "tcp_to_ws" => common::Direction::TcpToWs,
         &_ => {
             panic!("Got unknown direction, shouldn't be possible.");
         }
     };
 
     rt.block_on(async {
-        let res = common::serve(bind_value, dest_value, direction).await;
+        let res = common::serve(bind_value, dest_value, direction, proxy).await;
         panic!("Serve returned with {:?}", res);
     });
 


### PR DESCRIPTION
I only implemented proxy for `ws_to_tcp` since that's all we're using and IDK if it even makes sense in the other direction. I also only did v2 of the PROXY protocol.