### PR TITLE
Add argument for using a different Proxy HTTP header

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -21,6 +21,7 @@ pub async fn communicate(
     tcp_in: TcpOrDestination,
     ws_in: TcpOrDestination,
     proxy: bool,
+    proxy_header_name: &str,
 ) -> Result<(), Error> {
     let mut ws;
     let mut tcp;
@@ -37,7 +38,7 @@ pub async fn communicate(
                 |request: &Request<()>, response| {
                     forward_addr = request
                         .headers()
-                        .get("X-Forwarded-For")
+                        .get(proxy_header_name)
                         .and_then(|h| h.to_str().ok())
                         .and_then(|h| h.split(',').next())
                         .and_then(|addr| addr.trim().parse::<IpAddr>().ok());
@@ -285,6 +286,7 @@ pub async fn serve(
     dest_location: &str,
     dir: Direction,
     proxy: bool,
+    proxy_header_name: &str,
 ) -> Result<(), Error> {
     let listener = TcpListener::bind(bind_location)
         .await
@@ -328,7 +330,7 @@ pub async fn serve(
                 TcpOrDestination::Tcp(socket)
             }
         };
-        match communicate(in1, in2, proxy).await {
+        match communicate(in1, in2, proxy, proxy_header_name).await {
             Ok(_v) => {
                 info!("Succesfully setup communication.");
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,13 @@ fn main() -> Result<(), Error> {
                     .help("Enables PROXY protocol when running in ws_to_tcp mode"),
             )
             .arg(
+                Arg::new("proxy-header-name")
+                    .long("proxy-header-name")
+                    .default_value("X-Forwarded-For")
+                    .requires("proxy")
+                    .help("Get the original IP from this header when running in PROXY mode"),
+            )
+            .arg(
                 Arg::new("mode")
                     .value_parser(["ws_to_tcp", "tcp_to_ws"])
                     .required(true)
@@ -67,6 +74,7 @@ fn main() -> Result<(), Error> {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     let proxy = matches.get_flag("proxy");
+    let proxy_header_name = matches.get_one::<String>("proxy-header-name").unwrap();
     let direction = match matches
         .get_one::<String>("mode")
         .expect("`mode` is required")
@@ -80,7 +88,7 @@ fn main() -> Result<(), Error> {
     };
 
     rt.block_on(async {
-        let res = common::serve(bind_value, dest_value, direction, proxy).await;
+        let res = common::serve(bind_value, dest_value, direction, proxy, proxy_header_name).await;
         panic!("Serve returned with {:?}", res);
     });
 


### PR DESCRIPTION
This can be used to get the IP from the `CF-Connecting-IP` header instead.